### PR TITLE
Fix precise & xenial & bionic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ matrix:
   - os: linux
     dist: trusty
     sudo: required
+  - os: linux
+    dist: xenial 
+    sudo: required
   - os: osx
   allow_failures:
   - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,10 @@ matrix:
     dist: trusty
     sudo: required
   - os: linux
-    dist: xenial 
+    dist: xenial
+    sudo: required
+  - os: linux
+    dist: bionic
     sudo: required
   - os: osx
   allow_failures:

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@
 TARGET := main
 
 OS := $(shell uname -s)
+VERSION := $(shell lsb_release -rs 2> /dev/null)
 LATEXMK := $(shell command -v latexmk 2> /dev/null)
 LATEXMK_OPTION := -time -recorder -rules
 LATEXMK_EXEC := latexmk $(LATEXMK_OPTION)
@@ -38,7 +39,11 @@ install:
 ifndef LATEXMK
 	@echo 'installing components...'
 ifeq ($(OS), Linux)
+ifeq ($(VERSION), 14.04)
 	sudo apt install -y -qq texlive texlive-lang-cjk texlive-science texlive-fonts-recommended texlive-fonts-extra xdvik-ja dvipsk-ja gv latexmk
+else
+	sudo apt install -y -qq texlive texlive-lang-cjk texlive-lang-japanese texlive-science texlive-fonts-recommended texlive-fonts-extra xdvik-ja gv latexmk
+endif
 endif
 ifeq ($(OS), Darwin)
 	brew tap caskroom/cask && brew cask install -v mactex && sudo tlmgr update --self --all

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,9 @@ install:
 ifndef LATEXMK
 	@echo 'installing components...'
 ifeq ($(OS), Linux)
-ifeq ($(VERSION), 14.04)
+ifeq ($(VERSION), 12.04)
+	sudo apt-get install -y -qq texlive texlive-lang-cjk texlive-science texlive-fonts-recommended texlive-fonts-extra xdvik-ja dvipsk-ja gv latexmk
+else ifeq ($(VERSION), 14.04)
 	sudo apt install -y -qq texlive texlive-lang-cjk texlive-science texlive-fonts-recommended texlive-fonts-extra xdvik-ja dvipsk-ja gv latexmk
 else
 	sudo apt install -y -qq texlive texlive-lang-cjk texlive-lang-japanese texlive-science texlive-fonts-recommended texlive-fonts-extra xdvik-ja gv latexmk

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ ifeq ($(VERSION), 12.04)
 else ifeq ($(VERSION), 14.04)
 	sudo apt install -y -qq texlive texlive-lang-cjk texlive-science texlive-fonts-recommended texlive-fonts-extra xdvik-ja dvipsk-ja gv latexmk
 else
-	sudo apt install -y -qq texlive texlive-lang-cjk texlive-lang-japanese texlive-science texlive-fonts-recommended texlive-fonts-extra xdvik-ja gv latexmk
+	sudo apt install -y -qq texlive texlive-lang-cjk texlive-lang-japanese texlive-science texlive-fonts-recommended texlive-fonts-extra texlive-latex-extra xdvik-ja gv latexmk
 endif
 endif
 ifeq ($(OS), Darwin)

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Latex template for doctor entrance exam abst
 # only for ubuntu 12.04
 $ sudo apt-add-repository ppa:texlive-backports/ppa
 $ sudo apt-get update
+$ sudo apt-get install lsb-release
 ```
 
 ### 2. Edit LaTeX files


### PR DESCRIPTION
Similar to https://github.com/jsk-report-template/robomech-template/pull/3, but this PR additionally installs `texlive-latex-extra` on xenial and bionic.
This is because [this repo uses secdot](https://github.com/jsk-report-template/doctor-ent-exam-abst/blob/41c78625444b8657022e2a4553f82bbc009bcbe7/main.tex#L5), which is included in `texlive-latex-extra`:
https://ubuntu.pkgs.org/18.04/ubuntu-universe-amd64/texlive-latex-extra-doc_2017.20180305-2_all.deb.html